### PR TITLE
Generate configuration with generic template

### DIFF
--- a/koya-slider-package/appConfig-default.json
+++ b/koya-slider-package/appConfig-default.json
@@ -13,11 +13,11 @@
     "site.global.pid_file": "${AGENT_WORK_ROOT}/app/run/koya.pid",
 
     "site.global.kafka_version": "${kafka.version}",
-    "site.global.xmx_val": "512m",
-    "site.global.xms_val": "128m",
+    "site.broker.xmx_val": "512m",
+    "site.broker.xms_val": "128m",
 
-    "site.broker.instance.name": "${USER}/${CLUSTER_NAME}",
-    "site.broker.zookeeper.connect": "${ZK_HOST}"
+    "site.server.instance.name": "${USER}/${CLUSTER_NAME}",
+    "site.server.zookeeper.connect": "${ZK_HOST}"
   },
   "components": {
     "broker": {

--- a/koya-slider-package/appConfig-default.json
+++ b/koya-slider-package/appConfig-default.json
@@ -16,8 +16,8 @@
     "site.broker.xmx_val": "512m",
     "site.broker.xms_val": "128m",
 
-    "site.server.instance.name": "${USER}/${CLUSTER_NAME}",
-    "site.server.zookeeper.connect": "${ZK_HOST}"
+    "site.broker.instance.name": "${USER}/${CLUSTER_NAME}",
+    "site.broker.zookeeper": "${ZK_HOST}"
   },
   "components": {
     "broker": {

--- a/koya-slider-package/appConfig-default.json
+++ b/koya-slider-package/appConfig-default.json
@@ -13,7 +13,7 @@
     "site.global.pid_file": "${AGENT_WORK_ROOT}/app/run/koya.pid",
 
     "site.global.kafka_version": "${kafka.version}",
-    "site.global.xmx_val": "256m",
+    "site.global.xmx_val": "512m",
     "site.global.xms_val": "128m",
 
     "site.broker.instance.name": "${USER}/${CLUSTER_NAME}",
@@ -21,8 +21,6 @@
   },
   "components": {
     "broker": {
-      "site.global.xmx_val": "512m",
-      "site.global.xms_val": "128m"
     },
     "slider-appmaster": {
       "jvm.heapsize": "256M"

--- a/koya-slider-package/configuration/broker.xml
+++ b/koya-slider-package/configuration/broker.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>zookeeper.connect</name>
+    <value>${@//site/global/zookeeper}/kafka/${@//site/global/instance.name}</value>
+  </property>
+  <property>
+    <name>broker.id</name>
+    <value>${@//site/global/app_container_tag}</value>
+  </property>
+  <property>
+    <name>log.dirs</name>
+    <value>${@//site/global/app_pid_dir}</value>
+  </property>
+  <property>
+    <name>content</name>
+    <value>
+{% for k,v in broker_config.iteritems() %}{{k}}={{v}}
+{% endfor %}
+    </value>
+  </property>
+</configuration>

--- a/koya-slider-package/configuration/broker.xml
+++ b/koya-slider-package/configuration/broker.xml
@@ -16,7 +16,7 @@
   <property>
     <name>content</name>
     <value>
-{% for k,v in broker_config.iteritems() %}{{k}}={{v}}
+{% for k,v in broker_config|dictsort %}{{k}}={{v}}
 {% endfor %}
     </value>
   </property>

--- a/koya-slider-package/configuration/server.xml
+++ b/koya-slider-package/configuration/server.xml
@@ -13,11 +13,4 @@
     <name>log.dirs</name>
     <value>${@//site/global/app_pid_dir}</value>
   </property>
-  <property>
-    <name>content</name>
-    <value>
-{% for k,v in broker_config|dictsort %}{{k}}={{v}}
-{% endfor %}
-    </value>
-  </property>
 </configuration>

--- a/koya-slider-package/configuration/server.xml
+++ b/koya-slider-package/configuration/server.xml
@@ -3,7 +3,7 @@
 <configuration>
   <property>
     <name>zookeeper.connect</name>
-    <value>${@//site/global/zookeeper}/kafka/${@//site/global/instance.name}</value>
+    <value>${@//site/broker/zookeeper}/kafka/${@//site/broker/instance.name}</value>
   </property>
   <property>
     <name>broker.id</name>

--- a/koya-slider-package/metainfo-default.xml
+++ b/koya-slider-package/metainfo-default.xml
@@ -12,12 +12,6 @@
         <category>MASTER</category>
         <minInstanceCount>1</minInstanceCount>
         <exportedConfigs>broker</exportedConfigs>
-        <!--componentExports>
-          <componentExport>
-            <name>host_port</name>
-            <value>${THIS_HOST}:${site.global.listen_port}</value>
-          </componentExport>
-        </componentExports-->
         <commandScript>
           <script>scripts/kafka.py</script>
           <scriptType>PYTHON</scriptType>
@@ -28,8 +22,8 @@
     <configFiles>
       <configFile>
         <type>xml</type>
-        <fileName>broker.xml</fileName>
-        <dictionaryName>broker</dictionaryName>
+        <fileName>server.xml</fileName>
+        <dictionaryName>server</dictionaryName>
       </configFile>
     </configFiles>
 

--- a/koya-slider-package/metainfo-default.xml
+++ b/koya-slider-package/metainfo-default.xml
@@ -25,13 +25,13 @@
       </component>
     </components>
 
-    <!--configFiles>
+    <configFiles>
       <configFile>
-        <type>properties</type>
-        <fileName>server.properties</fileName>
-        <dictionaryName>server</dictionaryName>
+        <type>xml</type>
+        <fileName>broker.xml</fileName>
+        <dictionaryName>broker</dictionaryName>
       </configFile>
-    </configFiles-->
+    </configFiles>
 
     <osSpecifics>
       <osSpecific>

--- a/koya-slider-package/package/scripts/kafka.py
+++ b/koya-slider-package/package/scripts/kafka.py
@@ -23,7 +23,7 @@ class Kafka(Script):
 
     # log the component configuration
     ppp = pprint.PrettyPrinter(indent=4)
-    logger.info("broker component config: " + ppp.pformat(params.brokerConfig))
+    logger.info("broker component config: " + ppp.pformat(params.broker_config))
 
     # log the environment variables
     logger.info("Env Variables:")
@@ -47,20 +47,19 @@ class Kafka(Script):
 
 
     # update the broker properties for different brokers
-    util.updating(params.app_root + "/config/server.properties", params.brokerConfig)
-    #File(format("{params.conf_dir}/server.properties"),
-    #     owner=params.app_user,
-    #     content=InlineTemplate(params.server_prop))
+    File(format("{params.conf_dir}/server.properties"),
+         owner=params.app_user,
+         content=InlineTemplate(params.broker_prop))
 
     # execute the process
     process_cmd = format("{app_root}/bin/kafka-server-start.sh {app_root}/config/server.properties")
     os.environ['LOG_DIR'] = params.app_log_dir + "/kafka"
     HEAP_OPT = ""
-    if 'xmx_val' in params.brokerConfig:
-        HEAP_OPT = HEAP_OPT + " -Xmx" + params.brokerConfig['xmx_val']
+    if params.xmx:
+        HEAP_OPT = HEAP_OPT + " -Xmx" + params.xmx
     pass
-    if 'xms_val' in params.brokerConfig:
-        HEAP_OPT = HEAP_OPT + " -Xms" + params.brokerConfig['xms_val']
+    if params.xms:
+        HEAP_OPT = HEAP_OPT + " -Xms" + params.xms
     pass
     if HEAP_OPT:
         os.environ['KAFKA_HEAP_OPTS'] = HEAP_OPT

--- a/koya-slider-package/package/scripts/kafka.py
+++ b/koya-slider-package/package/scripts/kafka.py
@@ -47,12 +47,13 @@ class Kafka(Script):
 
 
     # update the broker properties for different brokers
-    File(format("{params.conf_dir}/server.properties"),
+    broker_conf_file=format("{params.conf_dir}/server.slider.properties")
+    File(broker_conf_file,
          owner=params.app_user,
          content=InlineTemplate(params.broker_prop))
 
     # execute the process
-    process_cmd = format("{app_root}/bin/kafka-server-start.sh {app_root}/config/server.properties")
+    process_cmd = format("{app_root}/bin/kafka-server-start.sh {broker_conf_file}")
     os.environ['LOG_DIR'] = params.app_log_dir + "/kafka"
     HEAP_OPT = ""
     if params.xmx:

--- a/koya-slider-package/package/scripts/kafka.py
+++ b/koya-slider-package/package/scripts/kafka.py
@@ -45,15 +45,12 @@ class Kafka(Script):
 #           content=InlineTemplate(param.log4j_prop))
     pass
 
-
     # update the broker properties for different brokers
-    broker_conf_file=format("{params.conf_dir}/server.slider.properties")
-    File(broker_conf_file,
-         owner=params.app_user,
-         content=InlineTemplate(params.broker_prop))
+    server_conf=format("{params.conf_dir}/server.slider.properties")
+    PropertiesFile(server_conf, properties = params.broker_config, owner=params.app_user)
 
     # execute the process
-    process_cmd = format("{app_root}/bin/kafka-server-start.sh {broker_conf_file}")
+    process_cmd = format("{app_root}/bin/kafka-server-start.sh {server_conf}")
     os.environ['LOG_DIR'] = params.app_log_dir + "/kafka"
     HEAP_OPT = ""
     if params.xmx:

--- a/koya-slider-package/package/scripts/params.py
+++ b/koya-slider-package/package/scripts/params.py
@@ -9,8 +9,12 @@ app_user = config['configurations']['global']['app_user']
 pid_file = config['configurations']['global']['pid_file']
 app_log_dir = config['configurations']['global']['app_log_dir']
 kafka_version = config['configurations']['global']['kafka_version']
+xmx = config['configurations']['global']['xmx_val']
+xms = config['configurations']['global']['xms_val']
 
 conf_dir = format("{app_root}/config")
-brokerConfig = config['configurations']['broker'].copy()
-brokerConfig['broker.id'] = int(config['configurations']['global']['app_container_tag']) - 1
 
+broker_config=dict(line.strip().split('=') for line in open(format("{conf_dir}/server.properties")) if not (line.startswith('#') or re.match(r'^\s*$', line)))
+broker_config.update(config['configurations']['broker'])
+broker_prop=broker_config['content']
+del broker_config['content']

--- a/koya-slider-package/package/scripts/params.py
+++ b/koya-slider-package/package/scripts/params.py
@@ -9,12 +9,10 @@ app_user = config['configurations']['global']['app_user']
 pid_file = config['configurations']['global']['pid_file']
 app_log_dir = config['configurations']['global']['app_log_dir']
 kafka_version = config['configurations']['global']['kafka_version']
-xmx = config['configurations']['global']['xmx_val']
-xms = config['configurations']['global']['xms_val']
+xmx = config['configurations']['broker']['xmx_val']
+xms = config['configurations']['broker']['xms_val']
 
 conf_dir = format("{app_root}/config")
 
 broker_config=dict(line.strip().split('=') for line in open(format("{conf_dir}/server.properties")) if not (line.startswith('#') or re.match(r'^\s*$', line)))
-broker_config.update(config['configurations']['broker'])
-broker_prop=broker_config['content']
-del broker_config['content']
+broker_config.update(config['configurations']['server'])

--- a/koya-slider-package/resources-default.json
+++ b/koya-slider-package/resources-default.json
@@ -9,7 +9,7 @@
   "components" : {
     "broker" : {
       "yarn.role.priority" : "1",
-      "yarn.component.instances" : "10",
+      "yarn.component.instances" : "5",
       "yarn.memory" : "768",
       "yarn.vcores" : "1",
       "yarn.component.placement.policy":"1"


### PR DESCRIPTION
Hi,

I've done the configuration generation as described in email, adding the features you requested:
* Parse current configuration into config
* Add appConfig / built-in default to this configuration
* Finally regenerate the file

I think this is the right way to do it: future-proof, ability to just regenerate the file in any place, and ability to poke all configuration from python code (which the current search-and-replace does not allow).

Maybe we could take this a step further and write in a separate file on launch.

If you agree i'll do the same for log4j, and if you want separate file writing, don't hesitate.