### PR TITLE
Add rest gateway really

### DIFF
--- a/koya-slider-package/appConfig-default.json
+++ b/koya-slider-package/appConfig-default.json
@@ -11,17 +11,21 @@
     "site.global.app_root": "${AGENT_WORK_ROOT}/app/install/${kafka.version}",
     "site.global.app_install_dir": "${AGENT_WORK_ROOT}/app/install",
     "site.global.pid_file": "${AGENT_WORK_ROOT}/app/run/koya.pid",
-
     "site.global.kafka_version": "${kafka.version}",
+
     "site.broker.xmx_val": "512m",
     "site.broker.xms_val": "128m",
     "site.broker.instance.name": "${USER}/${CLUSTER_NAME}",
     "site.broker.zookeeper": "${ZK_HOST}",
 
-    "site.server.port": "${KAFKA_BROKER.ALLOCATED_PORT}{PER_CONTAINER}"
+    "site.server.port": "${KAFKA_BROKER.ALLOCATED_PORT}{PER_CONTAINER}",
+
+    "site.producer.metadata.broker.list": "kafka01:9092,kafka02:9092,kafka03:9092"
   },
   "components": {
-    "broker": {
+    "KAFKA_BROKER": {
+    },
+    "KAFKA_MIRROR": {
     },
     "slider-appmaster": {
       "jvm.heapsize": "256M"

--- a/koya-slider-package/appConfig-mirror-default.json
+++ b/koya-slider-package/appConfig-mirror-default.json
@@ -17,7 +17,7 @@
     "site.broker.zookeeper": "${ZK_HOST}",
 
     "site.consumer.zookeeper.connect": "10.60.32.120:2181,10.60.32.121:2181,10.60.32.122:2181/kafka_central",
-    "site.producer.metadata.broker.list": "a4-5d-36-fc-ff-70.hpc.criteo.preprod:51023,a4-5d-36-fc-ff-78.hpc.criteo.preprod:53216,"
+    "site.producer.metadata.broker.list": "a4-5d-36-fc-ff-70.hpc.criteo.preprod:51023,a4-5d-36-fc-ff-78.hpc.criteo.preprod:53216"
   },
   "components": {
     "KAFKA_MIRROR": {

--- a/koya-slider-package/appConfig-mirror-default.json
+++ b/koya-slider-package/appConfig-mirror-default.json
@@ -1,0 +1,29 @@
+{
+  "schema": "http://example.org/specification/v2.0.0",
+  "metadata": {
+  },
+  "global": {
+    "application.def": ".slider/package/KOYA/koya-slider-package-${project.version}.zip",
+    "java_home": "${JAVA_HOME}",
+    "system_configs": "broker",
+
+    "site.global.app_user": "${USER_NAME}",
+    "site.global.app_root": "${AGENT_WORK_ROOT}/app/install/${kafka.version}",
+    "site.global.app_install_dir": "${AGENT_WORK_ROOT}/app/install",
+    "site.global.pid_file": "${AGENT_WORK_ROOT}/app/run/koya.pid",
+    "site.global.kafka_version": "${kafka.version}",
+
+    "site.broker.instance.name": "${USER}/${CLUSTER_NAME}",
+    "site.broker.zookeeper": "${ZK_HOST}",
+
+    "site.consumer.zookeeper.connect": "10.60.32.120:2181,10.60.32.121:2181,10.60.32.122:2181/kafka_central",
+    "site.producer.metadata.broker.list": "a4-5d-36-fc-ff-70.hpc.criteo.preprod:51023,a4-5d-36-fc-ff-78.hpc.criteo.preprod:53216,"
+  },
+  "components": {
+    "KAFKA_MIRROR": {
+    },
+    "slider-appmaster": {
+      "jvm.heapsize": "256M"
+    }
+  }
+}

--- a/koya-slider-package/appConfig-rest-default.json
+++ b/koya-slider-package/appConfig-rest-default.json
@@ -1,0 +1,28 @@
+{
+  "schema": "http://example.org/specification/v2.0.0",
+  "metadata": {
+  },
+  "global": {
+    "application.def": ".slider/package/KOYA/koya-slider-package-${project.version}.zip",
+    "java_home": "${JAVA_HOME}",
+    "system_configs": "broker",
+
+    "site.global.app_user": "${USER_NAME}",
+    "site.global.app_root": "${AGENT_WORK_ROOT}/app/install/${kafka.version}",
+    "site.global.app_install_dir": "${AGENT_WORK_ROOT}/app/install",
+    "site.global.pid_file": "${AGENT_WORK_ROOT}/app/run/koya.pid",
+    "site.global.kafka_version": "${kafka.version}",
+
+    "site.broker.instance.name": "${USER}/${CLUSTER_NAME}",
+    "site.broker.zookeeper": "${ZK_HOST}",
+
+    "site.rest.metadata.broker.list": "a4-5d-36-fc-ff-70.hpc.criteo.preprod:51023,a4-5d-36-fc-ff-78.hpc.criteo.preprod:53216,"
+  },
+  "components": {
+    "KAFKA_REST": {
+    },
+    "slider-appmaster": {
+      "jvm.heapsize": "256M"
+    }
+  }
+}

--- a/koya-slider-package/appConfig-rest-default.json
+++ b/koya-slider-package/appConfig-rest-default.json
@@ -16,7 +16,8 @@
     "site.broker.instance.name": "${USER}/${CLUSTER_NAME}",
     "site.broker.zookeeper": "${ZK_HOST}",
 
-    "site.rest.metadata.broker.list": "a4-5d-36-fc-ff-70.hpc.criteo.preprod:51023,a4-5d-36-fc-ff-78.hpc.criteo.preprod:53216,"
+    "site.kafka-rest.zookeeper.connect": "${@//site/broker/zookeeper}/kafka/jb.note/koya",
+    "site.kafka-rest.bootstrap.servers": "a4-5d-36-fc-ff-70.hpc.criteo.preprod:51023,a4-5d-36-fc-ff-78.hpc.criteo.preprod:53216"
   },
   "components": {
     "KAFKA_REST": {

--- a/koya-slider-package/build.sh
+++ b/koya-slider-package/build.sh
@@ -4,6 +4,8 @@ SOURCE=http://apache.websitebeheerjd.nl/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz
 TARGET=$HOME/$(basename $SOURCE)
 VERSION=$(basename $TARGET .tgz)
 
+CONFIGS="appConfig.json appConfig-mirror.json resources.json resources-mirror.json"
+
 wget $SOURCE -O $TARGET
 mvn clean install -DskipTests -Dkafka.src=$TARGET -Dkafka.version=$PREFIX
 unzip -o target/koya-slider-package-0.1.zip appConfig.json appConfig-mirror.json resources.json resources-mirror.json

--- a/koya-slider-package/build.sh
+++ b/koya-slider-package/build.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
-wget http://apache.websitebeheerjd.nl/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz -O $HOME/kafka_2.10-0.8.2.1.tgz
-mvn clean install -DskipTests -Dkafka.src=$HOME/kafka_2.10-0.8.2.1.tgz -Dkafka.version=kafka_2.10-0.8.2.1
+SOURCE=http://apache.websitebeheerjd.nl/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz
+TARGET=$HOME/$(basename $SOURCE)
+VERSION=$(basename $TARGET .tgz)
+
+wget $SOURCE -O $TARGET
+mvn clean install -DskipTests -Dkafka.src=$TARGET -Dkafka.version=$PREFIX
 unzip -o target/koya-slider-package-0.1.zip appConfig.json appConfig-mirror.json resources.json resources-mirror.json

--- a/koya-slider-package/build.sh
+++ b/koya-slider-package/build.sh
@@ -2,4 +2,4 @@
 
 wget http://apache.websitebeheerjd.nl/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz -O $HOME/kafka_2.10-0.8.2.1.tgz
 mvn clean install -DskipTests -Dkafka.src=$HOME/kafka_2.10-0.8.2.1.tgz -Dkafka.version=kafka_2.10-0.8.2.1
-unzip -o target/koya-slider-package-0.1.zip appConfig.json
+unzip -o target/koya-slider-package-0.1.zip appConfig.json appConfig-mirror.json resources.json resources-mirror.json

--- a/koya-slider-package/build_confluent.sh
+++ b/koya-slider-package/build_confluent.sh
@@ -4,6 +4,7 @@ SOURCE=http://packages.confluent.io/archive/1.0/confluent-1.0-2.10.4.tar.gz
 TARGET=$HOME/$(basename $SOURCE)
 VERSION=$(echo $(basename $SOURCE) | cut -f1,2 -d'-')
 
+CONFIGS="appConfig.json appConfig-mirror.json appConfig-rest.json resources.json resources-mirror.json resources-rest.json"
+
 wget $SOURCE -O $TARGET
 mvn clean install -DskipTests -Dkafka.src=$TARGET -Dkafka.version=$VERSION
-unzip -o target/koya-slider-package-0.1.zip appConfig.json appConfig-mirror.json resources.json resources-mirror.json

--- a/koya-slider-package/build_confluent.sh
+++ b/koya-slider-package/build_confluent.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+SOURCE=http://packages.confluent.io/archive/1.0/confluent-1.0-2.10.4.tar.gz
+TARGET=$HOME/$(basename $SOURCE)
+VERSION=$(echo $(basename $SOURCE) | cut -f1,2 -d'-')
+
+wget $SOURCE -O $TARGET
+mvn clean install -DskipTests -Dkafka.src=$TARGET -Dkafka.version=$VERSION
+unzip -o target/koya-slider-package-0.1.zip appConfig.json appConfig-mirror.json resources.json resources-mirror.json

--- a/koya-slider-package/configuration/consumer.xml
+++ b/koya-slider-package/configuration/consumer.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>zookeeper.connect</name>
+    <value>${@//site/global/zookeeper}/kafka/${@//site/global/instance.name}</value>
+  </property>
+  <property>
+    <name>group.id</name>
+    <value>koya-${@//site/global/app_user}</value>
+  </property>
+</configuration>

--- a/koya-slider-package/configuration/consumer.xml
+++ b/koya-slider-package/configuration/consumer.xml
@@ -7,6 +7,6 @@
   </property>
   <property>
     <name>group.id</name>
-    <value>koya-${@//site/global/app_user}</value>
+    <value>koya-mirror-${@//site/global/app_user}</value>
   </property>
 </configuration>

--- a/koya-slider-package/configuration/consumer.xml
+++ b/koya-slider-package/configuration/consumer.xml
@@ -3,7 +3,7 @@
 <configuration>
   <property>
     <name>zookeeper.connect</name>
-    <value>${@//site/global/zookeeper}/kafka/${@//site/global/instance.name}</value>
+    <value>${@//site/broker/zookeeper}/kafka/${@//site/broker/instance.name}</value>
   </property>
   <property>
     <name>group.id</name>

--- a/koya-slider-package/configuration/kafka-rest.xml
+++ b/koya-slider-package/configuration/kafka-rest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>id</name>
+    <value>koya-rest-${@//site/global/app_user}</value>
+  </property>
+  <property>
+    <name>zookeeper.connect</name>
+    <value>${@//site/broker/zookeeper}/kafka/${@//site/broker/instance.name}</value>
+  </property>
+</configuration>

--- a/koya-slider-package/configuration/mirror.xml
+++ b/koya-slider-package/configuration/mirror.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>xmx</name>
+    <value>256m</value>
+  </property>
+  <property>
+    <name>xms</name>
+    <value>128m</value>
+  </property>
+  <property>
+    <name>num.streams</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>num.producers</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>queue.size</name>
+    <value>10000</value>
+  </property>
+  <property>
+    <name>whitelist</name>
+    <value>.*</value>
+  </property>
+</configuration>

--- a/koya-slider-package/configuration/producer.xml
+++ b/koya-slider-package/configuration/producer.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>client.id</name>
+    <value>koya-${@//site/global/app_container_tag}</value>
+  </property>
+</configuration>

--- a/koya-slider-package/configuration/rest.xml
+++ b/koya-slider-package/configuration/rest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>xmx</name>
+    <value>256m</value>
+  </property>
+  <property>
+    <name>xms</name>
+    <value>128m</value>
+  </property>
+</configuration>

--- a/koya-slider-package/deploy-component.sh
+++ b/koya-slider-package/deploy-component.sh
@@ -7,4 +7,5 @@ for action in stop destroy; do
     slider $action ${APPNAME}-${COMPONENT}
 done
 # Will mirror with source defined in appConfig-mirror.json -- may need customization
+unzip -o target/koya-slider-package-0.1.zip appConfig-${COMPONENT}.json resources-${COMPONENT}.json
 slider create ${APPNAME}-${COMPONENT} --filesystem hdfs://root --queue dev --template appConfig-${COMPONENT}.json --resources resources-${COMPONENT}.json

--- a/koya-slider-package/deploy-component.sh
+++ b/koya-slider-package/deploy-component.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+COMPONENT=${1:-""}
+APPNAME=${2:-koya}
+slider package --install --replacepkg --name KOYA --package target/koya-slider-package-0.1.zip
+for action in stop destroy; do
+    slider $action ${APPNAME}-${COMPONENT}
+done
+# Will mirror with source defined in appConfig-mirror.json -- may need customization
+slider create ${APPNAME}-${COMPONENT} --filesystem hdfs://root --queue dev --template appConfig-${COMPONENT}.json --resources resources-${COMPONENT}.json

--- a/koya-slider-package/deploy-mirror.sh
+++ b/koya-slider-package/deploy-mirror.sh
@@ -1,10 +1,9 @@
 #! /bin/bash
 
 APPNAME=${1:-koya}
-slider install-package --replacepkg --name KOYA --package target/koya-slider-package-0.1.zip
+slider package --install --replacepkg --name KOYA --package target/koya-slider-package-0.1.zip
 for action in stop destroy; do
-    slider $action $APPNAME
+    slider $action ${APPNAME}-mirror
 done
-#slider create $APPNAME --filesystem hdfs://root --queue dev --template appConfig.json --resources resources.json
 # Will mirror with source defined in appConfig-mirror.json -- may need customization
 slider create ${APPNAME}-mirror --filesystem hdfs://root --queue dev --template appConfig-mirror.json --resources resources-mirror.json

--- a/koya-slider-package/deploy-mirror.sh
+++ b/koya-slider-package/deploy-mirror.sh
@@ -1,9 +1,4 @@
 #! /bin/bash
 
-APPNAME=${1:-koya}
-slider package --install --replacepkg --name KOYA --package target/koya-slider-package-0.1.zip
-for action in stop destroy; do
-    slider $action ${APPNAME}-mirror
-done
-# Will mirror with source defined in appConfig-mirror.json -- may need customization
-slider create ${APPNAME}-mirror --filesystem hdfs://root --queue dev --template appConfig-mirror.json --resources resources-mirror.json
+base_dir=$(dirname $0)
+exec $base_dir/deploys-component.sh mirror $@

--- a/koya-slider-package/deploy-mirror.sh
+++ b/koya-slider-package/deploy-mirror.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 
 base_dir=$(dirname $0)
-exec $base_dir/deploys-component.sh mirror $@
+exec $base_dir/deploy-component.sh mirror $@

--- a/koya-slider-package/deploy-rest.sh
+++ b/koya-slider-package/deploy-rest.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 base_dir=$(dirname $0)
-exec $base_dir/deploys-component.sh rest $@
+exec $base_dir/deploy-component.sh rest $@

--- a/koya-slider-package/deploy-rest.sh
+++ b/koya-slider-package/deploy-rest.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+base_dir=$(dirname $0)
+exec $base_dir/deploys-component.sh rest $@

--- a/koya-slider-package/deploy.sh
+++ b/koya-slider-package/deploy.sh
@@ -8,4 +8,3 @@ slider create $APPNAME --filesystem hdfs://root --queue dev --template appConfig
 
 
 
-

--- a/koya-slider-package/deploy.sh
+++ b/koya-slider-package/deploy.sh
@@ -1,10 +1,10 @@
 #! /bin/bash
 
 APPNAME=${1:-koya}
-slider install-package --replacepkg --name KOYA --package target/koya-slider-package-0.1.zip
+slider package --install --replacepkg --name KOYA --package target/koya-slider-package-0.1.zip
 for action in stop destroy; do
     slider $action $APPNAME
 done
-#slider create $APPNAME --filesystem hdfs://root --queue dev --template appConfig.json --resources resources.json
 # Will mirror with source defined in appConfig-mirror.json -- may need customization
+unzip -o target/koya-slider-package-0.1.zip appConfig.json resources.json
 slider create ${APPNAME}-mirror --filesystem hdfs://root --queue dev --template appConfig-mirror.json --resources resources-mirror.json

--- a/koya-slider-package/metainfo-default.xml
+++ b/koya-slider-package/metainfo-default.xml
@@ -40,6 +40,16 @@
           <scriptType>PYTHON</scriptType>
         </commandScript>
       </component>
+      <component>
+        <name>KAFKA_REST</name>
+        <category>SLAVE</category>
+        <minInstanceCount>0</minInstanceCount>
+        <exportedConfigs>rest</exportedConfigs>
+        <commandScript>
+          <script>scripts/rest.py</script>
+          <scriptType>PYTHON</scriptType>
+        </commandScript>
+      </component>
     </components>
 
     <configFiles>

--- a/koya-slider-package/metainfo-default.xml
+++ b/koya-slider-package/metainfo-default.xml
@@ -44,7 +44,7 @@
         <name>KAFKA_REST</name>
         <category>SLAVE</category>
         <minInstanceCount>0</minInstanceCount>
-        <exportedConfigs>rest</exportedConfigs>
+        <exportedConfigs>kafka-rest</exportedConfigs>
         <commandScript>
           <script>scripts/rest.py</script>
           <scriptType>PYTHON</scriptType>
@@ -72,6 +72,16 @@
         <type>xml</type>
         <fileName>mirror.xml</fileName>
         <dictionaryName>mirror</dictionaryName>
+      </configFile>
+      <configFile>
+        <type>xml</type>
+        <fileName>rest.xml</fileName>
+        <dictionaryName>rest</dictionaryName>
+      </configFile>
+      <configFile>
+        <type>xml</type>
+        <fileName>kafka-rest.xml</fileName>
+        <dictionaryName>kafka-rest</dictionaryName>
       </configFile>
     </configFiles>
 

--- a/koya-slider-package/metainfo-default.xml
+++ b/koya-slider-package/metainfo-default.xml
@@ -22,11 +22,21 @@
       <component>
         <name>KAFKA_BROKER</name>
         <category>SLAVE</category>
-        <minInstanceCount>1</minInstanceCount>
+        <minInstanceCount>0</minInstanceCount>
         <compExports>servers-org.apache.kafka.broker</compExports>
         <exportedConfigs>broker</exportedConfigs>
         <commandScript>
           <script>scripts/kafka.py</script>
+          <scriptType>PYTHON</scriptType>
+        </commandScript>
+      </component>
+      <component>
+        <name>KAFKA_MIRROR</name>
+        <category>SLAVE</category>
+        <minInstanceCount>0</minInstanceCount>
+        <exportedConfigs>mirror</exportedConfigs>
+        <commandScript>
+          <script>scripts/mirror.py</script>
           <scriptType>PYTHON</scriptType>
         </commandScript>
       </component>
@@ -37,6 +47,21 @@
         <type>xml</type>
         <fileName>server.xml</fileName>
         <dictionaryName>server</dictionaryName>
+      </configFile>
+      <configFile>
+        <type>xml</type>
+        <fileName>producer.xml</fileName>
+        <dictionaryName>producer</dictionaryName>
+      </configFile>
+      <configFile>
+        <type>xml</type>
+        <fileName>consumer.xml</fileName>
+        <dictionaryName>consumer</dictionaryName>
+      </configFile>
+      <configFile>
+        <type>xml</type>
+        <fileName>mirror.xml</fileName>
+        <dictionaryName>mirror</dictionaryName>
       </configFile>
     </configFiles>
 

--- a/koya-slider-package/package/scripts/mirror.py
+++ b/koya-slider-package/package/scripts/mirror.py
@@ -51,9 +51,9 @@ class MirrorMaker(Script):
     if HEAP_OPTS:
         os.environ['KAFKA_HEAP_OPTS'] = " ".join(HEAP_OPTS)
 
-    os.environ['LOG_DIR'] = params.app_log_dir + "/kafka_mirror"
-    os.environ['DAEMON_MODE'] = "true"
-    os.environ['CONSOLE_OUTPUT_FILE'] = params.app_log_dir + "/kafka.log"
+    os.environ['LOG_DIR'] = params.app_log_dir
+#    os.environ['DAEMON_MODE'] = "true"
+#    os.environ['CONSOLE_OUTPUT_FILE'] = params.app_log_dir + "/kafka.log"
     Execute(process_cmd,
         user=params.app_user,
         logoutput=True,

--- a/koya-slider-package/package/scripts/mirror.py
+++ b/koya-slider-package/package/scripts/mirror.py
@@ -1,0 +1,84 @@
+import logging
+import sys
+import os
+import inspect
+import pprint
+import util
+from resource_management import *
+
+logger = logging.getLogger()
+
+class MirrorMaker(Script):
+  def install(self, env):
+    self.install_packages(env)
+
+  def configure(self, env):
+    import params
+    env.set_params(params)
+
+  def start(self, env):
+    import params
+    env.set_params(params)
+    self.configure(env)
+
+    # update the broker properties for different brokers
+    confs={}
+    for endpoint in ["consumer", "producer"]:
+      conf=format("{params.conf_dir}/{endpoint}.slider.properties")
+      confs[endpoint] = conf
+      PropertiesFile(conf,
+                     properties = params.rich_config[endpoint],
+                     owner=params.app_user)
+
+    # execute the process
+    # We could probably fit consumer.conf and producer.config there
+    # too and remove the xmx hack
+    mirror_args=[]
+    for k,v in params.configs['mirror'].iteritems():
+      if k not in ["xmx", "xms"]:
+        mirror_args += [format("--{k}={v}")]
+
+    mirror_joinedargs=" ".join(mirror_args)
+    process_cmd = format("{app_root}/bin/kafka-mirror-maker.sh --consumer.config {consumer} --producer.config {producer} {mirror_joinedargs}",
+                         **confs)
+
+    HEAP_OPTS = []
+    for xopt in ["mx", "ms"]:
+      xoptval=params.configs['mirror'][format('x{xopt}')]
+      if xoptval:
+        HEAP_OPTS += [format("-X{xopt}{xoptval}")]
+
+    if HEAP_OPTS:
+        os.environ['KAFKA_HEAP_OPTS'] = " ".join(HEAP_OPTS)
+
+    os.environ['LOG_DIR'] = params.app_log_dir + "/kafka_mirror"
+    os.environ['DAEMON_MODE'] = "true"
+    os.environ['CONSOLE_OUTPUT_FILE'] = params.app_log_dir + "/kafka.log"
+    Execute(process_cmd,
+        user=params.app_user,
+        logoutput=True,
+        wait_for_finish=False,
+        pid_file=params.pid_file
+    )
+
+  def stop(self, env):
+    import params
+    env.set_params(params)
+    pid = format("`cat {pid_file}` >/dev/null 2>&1")
+    Execute(format("kill {pid}"),
+      user=params.app_user
+    )
+    Execute(format("kill -9 {pid}"),
+      ignore_failures=True,
+      user=params.app_user
+    )
+    Execute(format("rm -f {pid_file}"),
+      user=params.app_user)
+
+  def status(self, env):
+    import status_params
+    env.set_params(status_params)
+    check_process_status(status_params.pid_file)
+
+if __name__ == "__main__":
+  MirrorMaker().execute()

--- a/koya-slider-package/package/scripts/params.py
+++ b/koya-slider-package/package/scripts/params.py
@@ -1,7 +1,7 @@
 from resource_management import *
 
 config = Script.get_config()
-
+configs = config['configurations']
 
 app_root = config['configurations']['global']['app_root']
 java64_home = config['hostLevelParams']['java_home']
@@ -9,10 +9,21 @@ app_user = config['configurations']['global']['app_user']
 pid_file = config['configurations']['global']['pid_file']
 app_log_dir = config['configurations']['global']['app_log_dir']
 kafka_version = config['configurations']['global']['kafka_version']
-xmx = config['configurations']['broker']['xmx_val']
-xms = config['configurations']['broker']['xms_val']
+xmx = configs['broker']['xmx_val']
+xms = configs['broker']['xms_val']
 
 conf_dir = format("{app_root}/config")
 
-broker_config=dict(line.strip().split('=') for line in open(format("{conf_dir}/server.properties")) if not (line.startswith('#') or re.match(r'^\s*$', line)))
-broker_config.update(config['configurations']['server'])
+def enrich_dict(conf_file, conf_key):
+    deffile=format("{conf_dir}/{conf_file}", conf_dir=conf_dir, conf_file=conf_file)
+    default_config=dict(line.strip().split('=') for line in open(deffile) if not (line.startswith('#') or re.match(r'^\s*$', line)))
+    default_config.update(configs[conf_key])
+    return default_config
+
+rich_config={}
+def enrich(endpoint):
+    rich_config[endpoint] = enrich_dict(format("{endpoint}.properties"), endpoint)
+map(enrich, ["consumer", "producer", "server"])
+
+# For compatibility for now
+broker_config=rich_config['server']

--- a/koya-slider-package/package/scripts/params.py
+++ b/koya-slider-package/package/scripts/params.py
@@ -1,4 +1,5 @@
 from resource_management import *
+import os
 
 config = Script.get_config()
 configs = config['configurations']
@@ -12,18 +13,30 @@ kafka_version = config['configurations']['global']['kafka_version']
 xmx = configs['broker']['xmx_val']
 xms = configs['broker']['xms_val']
 
-conf_dir = format("{app_root}/config")
 
-def enrich_dict(conf_file, conf_key):
+conf_apache_dir = format("{app_root}/config")
+conf_confluent_dir = format("{app_root}/etc/kafka")
+conf_dir=conf_apache_dir if os.path.isdir(conf_apache_dir) else conf_confluent_dir
+rest_conf_dir = format("{app_root}/etc/kafka-rest")
+
+def enrich_dict(conf_dir, conf_file, conf_key):
     deffile=format("{conf_dir}/{conf_file}", conf_dir=conf_dir, conf_file=conf_file)
     default_config=dict(line.strip().split('=') for line in open(deffile) if not (line.startswith('#') or re.match(r'^\s*$', line)))
     default_config.update(configs[conf_key])
     return default_config
 
 rich_config={}
+def _enrich(conf_dir, endpoint):
+    rich_config[endpoint] = enrich_dict(conf_dir, format("{endpoint}.properties"), endpoint)
+
 def enrich(endpoint):
-    rich_config[endpoint] = enrich_dict(format("{endpoint}.properties"), endpoint)
+    _enrich(conf_dir, endpoint)
+
+def enrich_rest(endpoint):
+    _enrich(rest_conf_dir, endpoint)
+
 map(enrich, ["consumer", "producer", "server"])
+map(enrich_rest, ["kafka-rest"])
 
 # For compatibility for now
 broker_config=rich_config['server']

--- a/koya-slider-package/package/scripts/rest.py
+++ b/koya-slider-package/package/scripts/rest.py
@@ -1,0 +1,70 @@
+import logging
+import sys
+import os
+import inspect
+import pprint
+import util
+from resource_management import *
+
+logger = logging.getLogger()
+
+class Rest(Script):
+  def install(self, env):
+    self.install_packages(env)
+
+  def configure(self, env):
+    import params
+    env.set_params(params)
+
+  def start(self, env):
+    import params
+    env.set_params(params)
+    self.configure(env)
+
+    # update the broker properties for different brokers
+    conffile=format("{params.rest_conf_dir}/kafka-rest.slider.properties")
+    PropertiesFile(conffile,
+                   properties = params.rich_config["kafka-rest"],
+                   owner=params.app_user)
+
+    process_cmd = format("{app_root}/bin/kafka-rest-start {conffile}")
+
+    HEAP_OPTS = []
+    for xopt in ["mx", "ms"]:
+      xoptval=params.configs['rest'][format('x{xopt}')]
+      if xoptval:
+        HEAP_OPTS += [format("-X{xopt}{xoptval}")]
+
+    if HEAP_OPTS:
+        os.environ['KAFKAREST_HEAP_OPTS'] = " ".join(HEAP_OPTS)
+
+    os.environ['LOG_DIR'] = params.app_log_dir
+    # workaround bug in kafka-rest-run-class for the log4j of zip file
+    os.environ['KAFKAREST_LOG4J_OPTS'] = format("-Dlog4j.configuration=file:{params.rest_conf_dir}/log4j.properties")
+    Execute(process_cmd,
+            user=params.app_user,
+            logoutput=True,
+            wait_for_finish=False,
+            pid_file=params.pid_file)
+
+  def stop(self, env):
+    import params
+    env.set_params(params)
+    pid = format("`cat {pid_file}` >/dev/null 2>&1")
+    Execute(format("kill {pid}"),
+      user=params.app_user
+    )
+    Execute(format("kill -9 {pid}"),
+      ignore_failures=True,
+      user=params.app_user
+    )
+    Execute(format("rm -f {pid_file}"),
+      user=params.app_user)
+
+  def status(self, env):
+    import status_params
+    env.set_params(status_params)
+    check_process_status(status_params.pid_file)
+
+if __name__ == "__main__":
+  Rest().execute()

--- a/koya-slider-package/resources-default.json
+++ b/koya-slider-package/resources-default.json
@@ -9,10 +9,16 @@
   "components" : {
     "KAFKA_BROKER" : {
       "yarn.role.priority" : "1",
-      "yarn.component.instances" : "5",
+      "yarn.component.instances" : "2",
       "yarn.memory" : "768",
       "yarn.vcores" : "1",
       "yarn.component.placement.policy":"1"
+    },
+    "KAFKA_MIRROR" : {
+      "yarn.role.priority" : "2",
+      "yarn.component.instances" : "0",
+      "yarn.memory" : "512",
+      "yarn.vcores" : "1"
     },
     "slider-appmaster" : {
     }

--- a/koya-slider-package/resources-mirror-default.json
+++ b/koya-slider-package/resources-mirror-default.json
@@ -1,0 +1,19 @@
+{
+  "schema" : "http://example.org/specification/v2.0.0",
+  "metadata" : {
+  },
+  "global" : {
+    "yarn.container.failure.threshold":"10",
+    "yarn.container.failure.window.hours":"1"
+  },
+  "components" : {
+    "KAFKA_MIRROR" : {
+      "yarn.role.priority" : "1",
+      "yarn.component.instances" : "2",
+      "yarn.memory" : "512",
+      "yarn.vcores" : "1"
+    },
+    "slider-appmaster" : {
+    }
+  }
+}

--- a/koya-slider-package/resources-rest-default.json
+++ b/koya-slider-package/resources-rest-default.json
@@ -1,0 +1,19 @@
+{
+  "schema" : "http://example.org/specification/v2.0.0",
+  "metadata" : {
+  },
+  "global" : {
+    "yarn.container.failure.threshold":"10",
+    "yarn.container.failure.window.hours":"1"
+  },
+  "components" : {
+    "KAFKA_REST" : {
+      "yarn.role.priority" : "1",
+      "yarn.component.instances" : "1",
+      "yarn.memory" : "512",
+      "yarn.vcores" : "1"
+    },
+    "slider-appmaster" : {
+    }
+  }
+}

--- a/koya-slider-package/src/assembly/koya-app-package.xml
+++ b/koya-slider-package/src/assembly/koya-app-package.xml
@@ -36,8 +36,22 @@
       <fileMode>0755</fileMode>
     </file>
     <file>
+      <source>appConfig-mirror-default.json</source>
+      <destName>appConfig-mirror.json</destName>
+      <outputDirectory>/</outputDirectory>
+      <filtered>true</filtered>
+      <fileMode>0755</fileMode>
+    </file>
+    <file>
       <source>resources-default.json</source>
       <destName>resources.json</destName>
+      <outputDirectory>/</outputDirectory>
+      <filtered>true</filtered>
+      <fileMode>0755</fileMode>
+    </file>
+    <file>
+      <source>resources-mirror-default.json</source>
+      <destName>resources-mirror.json</destName>
       <outputDirectory>/</outputDirectory>
       <filtered>true</filtered>
       <fileMode>0755</fileMode>

--- a/koya-slider-package/src/assembly/koya-app-package.xml
+++ b/koya-slider-package/src/assembly/koya-app-package.xml
@@ -43,6 +43,13 @@
       <fileMode>0755</fileMode>
     </file>
     <file>
+      <source>appConfig-rest-default.json</source>
+      <destName>appConfig-rest.json</destName>
+      <outputDirectory>/</outputDirectory>
+      <filtered>true</filtered>
+      <fileMode>0755</fileMode>
+    </file>
+    <file>
       <source>resources-default.json</source>
       <destName>resources.json</destName>
       <outputDirectory>/</outputDirectory>
@@ -52,6 +59,13 @@
     <file>
       <source>resources-mirror-default.json</source>
       <destName>resources-mirror.json</destName>
+      <outputDirectory>/</outputDirectory>
+      <filtered>true</filtered>
+      <fileMode>0755</fileMode>
+    </file>
+    <file>
+      <source>resources-rest-default.json</source>
+      <destName>resources-rest.json</destName>
       <outputDirectory>/</outputDirectory>
       <filtered>true</filtered>
       <fileMode>0755</fileMode>


### PR DESCRIPTION
This piles upon the mirroring branch.
It adds support for running the REST gateway from the confluent release and also adds a build script for the confluent release.
I've not yet tested a full (BROKER + REST) setup which should be doable a desirable. will do as next iterations, this is just to get the ball rolling.
With these two MRs, i'm able to spawn a kafka cluster, a mirror from an external kafka cluster, and a REST gateway to the kafka cluster.
Service discovery is a WIP